### PR TITLE
Removed Socks from Proxy since it's a separate app already

### DIFF
--- a/applications.d/Proxy
+++ b/applications.d/Proxy
@@ -1,8 +1,3 @@
-[Socks]
-title=Socks proxy
-description=Socks proxy
-ports=1080/tcp
-
 [Transparent Proxy]
 title=Transparent proxy
 description=Transparent proxy


### PR DESCRIPTION
Both Socks (separate config file, Socks) and Proxy's Socks (Proxy file) conflict since they have the same app name.


I removed it from Proxy since it doesn't make sense to have Socks and Proxy

It ends up yielding a warning when reloading if you copy all the files:

   WARN: Duplicate profile 'Socks', using last found


